### PR TITLE
gitlab-ci-pipelines-exporter: Allow specifying existing `Secret`s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,14 @@ docs: ## Generate charts docs
 lint-kubeval: ## Lint the charts templated kubernetes values
 	@for chart in $(CHARTS); do \
 		helm dependency build $$chart; \
-		helm template --values $$chart/tests/kubeval.yaml $$chart | \
-		kubeval \
-			--strict \
-			-v $(KUBEVAL_SCHEMA_VERSION) \
-			-s $(KUBEVAL_SCHEMA_LOCATION); \
+		for values in $$chart/tests/*.yaml; do \
+			echo "\nTesting $$values..."; \
+			helm template --values $$values $$chart | \
+			kubeval \
+				--strict \
+				-v $(KUBEVAL_SCHEMA_VERSION) \
+				-s $(KUBEVAL_SCHEMA_LOCATION); \
+		done; \
 	done
 
 .PHONY: update-deps

--- a/charts/gitlab-ci-pipelines-exporter/templates/deployment.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/templates/deployment.yaml
@@ -57,8 +57,16 @@ spec:
 {{- with .Values.args }}
           args: {{ toYaml . | nindent 16 }}
 {{- end }}
+          env:
 {{- with .Values.envVariables }}
-          env: {{ toYaml . | nindent 16 }}
+          {{ toYaml . | nindent 10 }}
+{{- end }}
+{{- with .Values.gitlabSecret }}
+          - name: GCPE_GITLAB_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: {{ . }}
+                key: gitlabToken
 {{- end }}
           envFrom:
             - secretRef:

--- a/charts/gitlab-ci-pipelines-exporter/templates/deployment.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/templates/deployment.yaml
@@ -68,6 +68,13 @@ spec:
                 name: {{ . }}
                 key: gitlabToken
 {{- end }}
+{{- with .Values.webhookSecret}}
+          - name: GCPE_WEBHOOK_SECRET_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: {{ . }}
+                key: webhookToken
+{{- end }}
           envFrom:
             - secretRef:
                 name: {{ template "app.fullname" . }}-config

--- a/charts/gitlab-ci-pipelines-exporter/templates/secret.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/templates/secret.yaml
@@ -23,7 +23,7 @@ data:
 {{- end }}
 {{- if .Values.config.server }}
 {{- if .Values.config.server.webhook }}
-{{- if .Values.config.server.webhook.enabled }}
+{{- if (and .Values.config.server.webhook.enabled (not .Values.webhookSecret)) }}
   GCPE_WEBHOOK_SECRET_TOKEN: {{ required "webhook secret token must be set" .Values.config.server.webhook.secret_token | b64enc }}
 {{- end }}
 {{- end }}

--- a/charts/gitlab-ci-pipelines-exporter/templates/secret.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/templates/secret.yaml
@@ -11,9 +11,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 type: Opaque
 data:
-{{- if .Values.config.gitlab }}
+{{- if (and .Values.config.gitlab (not .Values.gitlabSecret)) }}
   GCPE_GITLAB_TOKEN: {{ required "gitlab token must be set" .Values.config.gitlab.token | b64enc }}
-{{- else }}
+{{- else if (not .Values.gitlabSecret) }}
 {{- fail "gitlab token must be set" }}
 {{- end }}
 {{- if .Values.config.redis }}

--- a/charts/gitlab-ci-pipelines-exporter/tests/with-existing-secrets.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/tests/with-existing-secrets.yaml
@@ -1,0 +1,7 @@
+---
+ingress:
+  enabled: true
+
+gitlabSecret: "foo"
+
+webhookSecret: "bar"

--- a/charts/gitlab-ci-pipelines-exporter/values.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/values.yaml
@@ -127,6 +127,9 @@ config: {}
   #       name: foo
   #       kind: group
 
+# -- name of a `Secret` containing the GitLab token in the `gitlabToken` field (required unless `config.gitlab.token` is specified)
+gitlabSecret: ""
+
 hostAliases: []
   # - ip: 192.168.0.1
   #   hostnames:

--- a/charts/gitlab-ci-pipelines-exporter/values.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/values.yaml
@@ -130,6 +130,9 @@ config: {}
 # -- name of a `Secret` containing the GitLab token in the `gitlabToken` field (required unless `config.gitlab.token` is specified)
 gitlabSecret: ""
 
+# -- name of a `Secret` containing the webhook token in the `webhookToken` field (required unless `config.server.webhook.secret_token` is specified)
+webhookSecret: ""
+
 hostAliases: []
   # - ip: 192.168.0.1
   #   hostnames:


### PR DESCRIPTION
This adds the ability to specify the name of `Secret`s for the GitLab API token and the webhook token instead of specifying the values directly. You can specify either, both, or none this way, and they expect the values to be under different keys, so the `Secret` can be the same for both if desired.

I also extended the Makefile to allow validating all YAML files under `tests/` so I could add tests for both directly specifying the values and specifying existing `Secret`s. These tests pass, and the revised chart works in a live cluster as well.

Closes #18 