### PR TITLE
Update tailscale-relay to v1.18.0

### DIFF
--- a/charts/tailscale-relay/Chart.yaml
+++ b/charts/tailscale-relay/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 name: tailscale-relay
 version: 0.1.0
-appVersion: v1.16.0
+appVersion: v1.18.0
 description: Deploy a tailscale relay on top of kubernetes
 home: https://github.com/mvisonneau/tailscale-relay-over-k8s
 sources:


### PR DESCRIPTION
We're using your chart to get access to our kubernetes cluster (thanks!) and have run into a bug in tailscale. We've been in touch with their support, and apparently it is fixes as part of:

https://github.com/tailscale/tailscale/issues/3088

We'd love to test the fix, but am struggling to find an easy way to do this without spinning up a helm charts repo, etc. I've optimistically made what I think is the change in the pull request but it is untested.

If you're able to merge it, I'd be able to test it tomorrow.

Another thought would be to release the current version with a parameter to allow me to override the version that's installed. This would probably be a nice feature anyway.