### PR TITLE
gitlab-ci-pipelines-exporter dublicate app.kubernetes.io/managed-by

### DIFF
--- a/charts/gitlab-ci-pipelines-exporter/templates/deployment.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/templates/deployment.yaml
@@ -20,7 +20,6 @@ spec:
     metadata:
       labels:
         {{- include "app.labels" . | nindent 8 }}
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
         helm.sh/from: deploy.{{ include "app.fullname" . }}
 {{ with .Values.podLabels }}{{ toYaml . | indent 8 }}{{ end }}
       annotations:


### PR DESCRIPTION
…iles

Helm install failed: error while running post render on files:
        map[string]interface {}(nil): yaml: unmarshal errors:
          line 34: mapping key "app.kubernetes.io/managed-by" already defined at line 32