### PR TITLE
Remove references to 1.22 deprecated apis in generic-app

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -33,14 +33,14 @@ jobs:
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint
+        run: ct lint --target-branch main
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        run: ct install
+        run: ct install --target-branch main
 
   helm-v3:
     runs-on: ubuntu-latest
@@ -71,14 +71,14 @@ jobs:
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint
+        run: ct lint --target-branch main
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        run: ct install
+        run: ct install --target-branch main
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,20 +13,31 @@ jobs:
       - name: Fetch history
         run: git fetch --prune --unshallow
 
-      - name: Run chart-testing (lint)
-        id: lint
-        uses: helm/chart-testing-action@dev-v2
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
         with:
-          command: lint
+          version: v2.17.0
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.2.1
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --targer-branch main)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Run chart-testing (lint)
+        run: ct lint
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0
-        if: steps.lint.outputs.changed == 'true'
+        uses: helm/kind-action@v1.2.0
+        if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        uses: helm/chart-testing-action@dev-v2
-        with:
-          command: install
+        run: ct install
 
   helm-v3:
     runs-on: ubuntu-latest
@@ -37,20 +48,31 @@ jobs:
       - name: Fetch history
         run: git fetch --prune --unshallow
 
-      - name: Run chart-testing (lint)
-        id: lint
-        uses: helm/chart-testing-action@v1.1.0
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
         with:
-          command: lint
+          version: v3.8.1
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.2.1
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --targer-branch main)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Run chart-testing (lint)
+        run: ct lint
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0
-        if: steps.lint.outputs.changed == 'true'
+        uses: helm/kind-action@v1.2.0
+        if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        uses: helm/chart-testing-action@v1.1.0
-        with:
-          command: install
+        run: ct install
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,10 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Fetch history
-        run: git fetch --prune --unshallow
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v2
         with:
@@ -47,10 +46,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Fetch history
-        run: git fetch --prune --unshallow
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v2
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -27,20 +27,20 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --target-branch main)
+          changed=$(ct list-changed --config ct.yaml)
           if [[ -n "$changed" ]]; then
             echo "::set-output name=changed::true"
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint --target-branch main
+        run: ct lint --config ct.yaml
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        run: ct install --target-branch main
+        run: ct install --config ct.yaml
 
   helm-v3:
     runs-on: ubuntu-latest
@@ -65,20 +65,20 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --target-branch main)
+          changed=$(ct list-changed --config ct.yaml)
           if [[ -n "$changed" ]]; then
             echo "::set-output name=changed::true"
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint --target-branch main
+        run: ct lint --config ct.yaml
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        run: ct install --target-branch main
+        run: ct install --config ct.yaml
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --targer-branch main)
+          changed=$(ct list-changed --target-branch main)
           if [[ -n "$changed" ]]; then
             echo "::set-output name=changed::true"
           fi
@@ -59,7 +59,7 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --targer-branch main)
+          changed=$(ct list-changed --target-branch main)
           if [[ -n "$changed" ]]; then
             echo "::set-output name=changed::true"
           fi

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,6 +13,10 @@ jobs:
       - name: Fetch history
         run: git fetch --prune --unshallow
 
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
@@ -47,6 +51,10 @@ jobs:
 
       - name: Fetch history
         run: git fetch --prune --unshallow
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
 
       - name: Set up Helm
         uses: azure/setup-helm@v1

--- a/.github/workflows/rebase.yaml
+++ b/.github/workflows/rebase.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/charts/generic-app/Chart.yaml
+++ b/charts/generic-app/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: Generic Application Chart
 name: generic-app
-version: 0.0.12
+version: 0.0.13
 appVersion: 0.0.0
 home: https://github.com/mvisonneau/helm-charts
 sources:

--- a/charts/generic-app/README.md
+++ b/charts/generic-app/README.md
@@ -1,6 +1,6 @@
 # generic-app
 
-![Version: 0.0.12](https://img.shields.io/badge/Version-0.0.12-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version: 0.0.13](https://img.shields.io/badge/Version-0.0.13-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
 
 Generic Application Chart
 

--- a/charts/generic-app/templates/horizontalpodautoscaler.yaml
+++ b/charts/generic-app/templates/horizontalpodautoscaler.yaml
@@ -7,7 +7,7 @@ metadata:
   {{- include "generic.labels" . | nindent 2 }}
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1beta2
+    apiVersion: apps/v1
     kind: Deployment
     name: {{ template "app.fullname" . }}
   minReplicas: {{ .Values.horizontalPodAutoscaler.minReplicas }}

--- a/charts/generic-app/values.yaml
+++ b/charts/generic-app/values.yaml
@@ -264,7 +264,7 @@ datadog:
 
   # global.datadog.version -- app version
   # version: (default to appVersion + release revision)
-  
+
 ##
 # Global configuration (ideal when embedding this chart within another)
 ##


### PR DESCRIPTION
# Summary

This should cover all of the deprecated APIs for 1.22 as per this doc
- https://kubernetes.io/docs/reference/using-api/deprecation-guide/#priorityclass-v122