### PR TITLE
upgrade tailscale app version to 1.22.2

### DIFF
--- a/charts/tailscale-relay/Chart.yaml
+++ b/charts/tailscale-relay/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: v2
 name: tailscale-relay
-version: 0.1.1
-appVersion: v1.18.2
+version: 0.1.2
+appVersion: v1.22.2
 description: Deploy a tailscale relay on top of kubernetes
 home: https://github.com/mvisonneau/tailscale-relay-over-k8s
 sources:

--- a/charts/tailscale-relay/README.md
+++ b/charts/tailscale-relay/README.md
@@ -1,6 +1,6 @@
 # tailscale-relay
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![AppVersion: v1.18.2](https://img.shields.io/badge/AppVersion-v1.18.2-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![AppVersion: v1.22.2](https://img.shields.io/badge/AppVersion-v1.22.2-informational?style=flat-square)
 
 Deploy a tailscale relay on top of kubernetes
 


### PR DESCRIPTION
upgrading the version of the docker-tailscale image to use v1.22.2 as
provided by PR: https://github.com/mvisonneau/docker-tailscale/pull/9