### PR TITLE
feat(gitlab-ci-pipelines-exporter): adds ability to set containerSecurityContext

### DIFF
--- a/charts/gitlab-ci-pipelines-exporter/Chart.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: gitlab-ci-pipelines-exporter
-version: 0.2.12
+version: 0.3.0
 appVersion: v0.5.3
 description: Prometheus / OpenMetrics exporter for GitLab CI pipelines insights
 home: https://github.com/mvisonneau/gitlab-ci-pipelines-exporter

--- a/charts/gitlab-ci-pipelines-exporter/Chart.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: gitlab-ci-pipelines-exporter
-version: 0.3.0
+version: 0.2.13
 appVersion: v0.5.3
 description: Prometheus / OpenMetrics exporter for GitLab CI pipelines insights
 home: https://github.com/mvisonneau/gitlab-ci-pipelines-exporter

--- a/charts/gitlab-ci-pipelines-exporter/templates/deployment.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/templates/deployment.yaml
@@ -42,6 +42,9 @@ spec:
         - name: {{ .Chart.Name }}
           image: {{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+{{- with .Values.containerSecurityContext }}
+          securityContext: {{ toYaml . | nindent 12 }}
+{{- end }}
 {{- with .Values.command }}
           command: {{ toYaml . | nindent 16 }}
 {{- end }}

--- a/charts/gitlab-ci-pipelines-exporter/values.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/values.yaml
@@ -101,6 +101,11 @@ affinity: {}
 securityContext:
   # runAsUser: 65534  # run as nobody user
 
+# containerSecurityContext -- security context to apply to the containers
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context
+containerSecurityContext:
+  # allowPrivilegeEscalation: false
+
 # command -- command for the exporter binary
 command:
   - gitlab-ci-pipelines-exporter


### PR DESCRIPTION
As the title states, it was possible to set the podSecurityContext but not the containerSecurityContext