### PR TITLE
chore(gitlab-ci-pipelines-exporter): indentation fixes

### DIFF
--- a/charts/gitlab-ci-pipelines-exporter/Chart.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: gitlab-ci-pipelines-exporter
-version: 0.3.1
+version: 0.2.13
 appVersion: v0.5.3
 description: Prometheus / OpenMetrics exporter for GitLab CI pipelines insights
 home: https://github.com/mvisonneau/gitlab-ci-pipelines-exporter

--- a/charts/gitlab-ci-pipelines-exporter/Chart.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: gitlab-ci-pipelines-exporter
-version: 0.2.12
+version: 0.3.1
 appVersion: v0.5.3
 description: Prometheus / OpenMetrics exporter for GitLab CI pipelines insights
 home: https://github.com/mvisonneau/gitlab-ci-pipelines-exporter

--- a/charts/gitlab-ci-pipelines-exporter/templates/deployment.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/templates/deployment.yaml
@@ -43,21 +43,21 @@ spec:
           image: {{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
 {{- with .Values.command }}
-          command: {{ toYaml . | nindent 16 }}
+          command: {{ toYaml . | nindent 12 }}
 {{- end }}
 {{- with .Values.args }}
-          args: {{ toYaml . | nindent 16 }}
+          args: {{ toYaml . | nindent 12 }}
 {{- end }}
           env:
 {{- with .Values.envVariables }}
-          {{ toYaml . | nindent 10 }}
+          {{ toYaml . | nindent 12 }}
 {{- end }}
 {{- with .Values.gitlabSecret }}
-          - name: GCPE_GITLAB_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: {{ . }}
-                key: gitlabToken
+            - name: GCPE_GITLAB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ . }}
+                  key: gitlabToken
 {{- end }}
 {{- with .Values.webhookSecret}}
           - name: GCPE_WEBHOOK_SECRET_TOKEN
@@ -78,10 +78,10 @@ spec:
               containerPort: 8080
               protocol: TCP
 {{- with .Values.livenessProbe }}
-          livenessProbe: {{ toYaml . | nindent 16 }}
+          livenessProbe: {{ toYaml . | nindent 12 }}
 {{- end }}
 {{- with .Values.readinessProbe }}
-          readinessProbe: {{ toYaml . | nindent 16 }}
+          readinessProbe: {{ toYaml . | nindent 12 }}
 {{- end }}
 {{- with .Values.resources }}
           resources: {{ toYaml . | nindent 12 }}


### PR DESCRIPTION
While I was working on #40 I found some style things in the yaml. Mostly over indented dicts, now all nice :)

### Before:
```yaml
---
# Source: gitlab-ci-pipelines-exporter/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: release-name-gitlab-ci-pipelines-exporter
  labels:
    app.kubernetes.io/name: gitlab-ci-pipelines-exporter
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v0.5.3"
    app.kubernetes.io/component: prometheus-exporter
    app.kubernetes.io/part-of: gitlab-ci-pipelines-exporter
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: gitlab-ci-pipelines-exporter-0.2.12

spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: gitlab-ci-pipelines-exporter
      app.kubernetes.io/instance: release-name
  strategy: 
    type: RollingUpdate
  template:
    metadata:
      labels:
        app.kubernetes.io/name: gitlab-ci-pipelines-exporter
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/version: "v0.5.3"
        app.kubernetes.io/component: prometheus-exporter
        app.kubernetes.io/part-of: gitlab-ci-pipelines-exporter
        app.kubernetes.io/managed-by: Helm
        helm.sh/chart: gitlab-ci-pipelines-exporter-0.2.12
        helm.sh/from: deploy.release-name-gitlab-ci-pipelines-exporter

      annotations:
        checksum/configmap: 175059b0d3f8ba8dfab20f4325eb6d8c7e2518f278bf762d6dde9904e5174577
        checksum/secret: 7937d7bf6be30342525ebb9e58ecb83e28a6d11a0d6dd54623a18a45456d66e7

    spec:
      containers:
        - name: gitlab-ci-pipelines-exporter
          image: quay.io/mvisonneau/gitlab-ci-pipelines-exporter:v0.5.3
          imagePullPolicy: IfNotPresent
          command: 
                - gitlab-ci-pipelines-exporter
                - run
          args: 
                - --config
                - /etc/config.yml
          env:
          
          - name: GCPE_INTERNAL_MONITORING_LISTENER_ADDRESS
            value: tcp://127.0.0.1:8082
          - name: GCPE_GITLAB_TOKEN
            valueFrom:
              secretKeyRef:
                name: test
                key: gitlabToken
          envFrom:
            - secretRef:
                name: release-name-gitlab-ci-pipelines-exporter-config
          volumeMounts:
            - name: config
              mountPath: /etc/config.yml
              subPath: config.yml
          ports:
            - name: exporter
              containerPort: 8080
              protocol: TCP
          livenessProbe: 
                httpGet:
                  path: /health/live
                  port: 8080
          readinessProbe: 
                failureThreshold: 3
                httpGet:
                  path: /health/ready
                  port: 8080
                initialDelaySeconds: 5
                periodSeconds: 30
                timeoutSeconds: 5
      volumes:
        - name: config
          configMap:
            name: release-name-gitlab-ci-pipelines-exporter-config
```

### After
```yaml
---
# Source: gitlab-ci-pipelines-exporter/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: release-name-gitlab-ci-pipelines-exporter
  labels:
    app.kubernetes.io/name: gitlab-ci-pipelines-exporter
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v0.5.3"
    app.kubernetes.io/component: prometheus-exporter
    app.kubernetes.io/part-of: gitlab-ci-pipelines-exporter
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: gitlab-ci-pipelines-exporter-0.3.1

spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: gitlab-ci-pipelines-exporter
      app.kubernetes.io/instance: release-name
  strategy: 
    type: RollingUpdate
  template:
    metadata:
      labels:
        app.kubernetes.io/name: gitlab-ci-pipelines-exporter
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/version: "v0.5.3"
        app.kubernetes.io/component: prometheus-exporter
        app.kubernetes.io/part-of: gitlab-ci-pipelines-exporter
        app.kubernetes.io/managed-by: Helm
        helm.sh/chart: gitlab-ci-pipelines-exporter-0.3.1
        helm.sh/from: deploy.release-name-gitlab-ci-pipelines-exporter

      annotations:
        checksum/configmap: 9ed52c25e4078a7954bd02c9445e421d7bfa9ba9aaf1e6c2d11e44893832fcc4
        checksum/secret: c3f7084940c60a49088bba3040b499b7fa837561b52fc86c45c7d23d376e3361

    spec:
      containers:
        - name: gitlab-ci-pipelines-exporter
          image: quay.io/mvisonneau/gitlab-ci-pipelines-exporter:v0.5.3
          imagePullPolicy: IfNotPresent
          command: 
            - gitlab-ci-pipelines-exporter
            - run
          args: 
            - --config
            - /etc/config.yml
          env:
          
            - name: GCPE_INTERNAL_MONITORING_LISTENER_ADDRESS
              value: tcp://127.0.0.1:8082
            - name: GCPE_GITLAB_TOKEN
              valueFrom:
                secretKeyRef:
                  name: test
                  key: gitlabToken
          envFrom:
            - secretRef:
                name: release-name-gitlab-ci-pipelines-exporter-config
          volumeMounts:
            - name: config
              mountPath: /etc/config.yml
              subPath: config.yml
          ports:
            - name: exporter
              containerPort: 8080
              protocol: TCP
          livenessProbe: 
            httpGet:
              path: /health/live
              port: 8080
          readinessProbe: 
            failureThreshold: 3
            httpGet:
              path: /health/ready
              port: 8080
            initialDelaySeconds: 5
            periodSeconds: 30
            timeoutSeconds: 5
      volumes:
        - name: config
          configMap:
            name: release-name-gitlab-ci-pipelines-exporter-config
```