### PR TITLE
fix env indentation in deployment.yaml

### DIFF
--- a/charts/gitlab-ci-pipelines-exporter/templates/deployment.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/templates/deployment.yaml
@@ -63,11 +63,11 @@ spec:
                   key: gitlabToken
 {{- end }}
 {{- with .Values.webhookSecret}}
-          - name: GCPE_WEBHOOK_SECRET_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: {{ . }}
-                key: webhookToken
+            - name: GCPE_WEBHOOK_SECRET_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ . }}
+                  key: webhookToken
 {{- end }}
           envFrom:
             - secretRef:


### PR DESCRIPTION
fix indentation of GCPE_WEBHOOK_SECRET_TOKEN env block