### PR TITLE
[gitlab-ci-pipelines-exporter]fix: adds secretName for ingress.tls

### DIFF
--- a/charts/gitlab-ci-pipelines-exporter/Chart.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: gitlab-ci-pipelines-exporter
-version: 0.2.16
+version: 0.2.17
 appVersion: v0.5.3
 description: Prometheus / OpenMetrics exporter for GitLab CI pipelines insights
 home: https://github.com/mvisonneau/gitlab-ci-pipelines-exporter

--- a/charts/gitlab-ci-pipelines-exporter/README.md
+++ b/charts/gitlab-ci-pipelines-exporter/README.md
@@ -1,6 +1,6 @@
 # gitlab-ci-pipelines-exporter
 
-![Version: 0.2.16](https://img.shields.io/badge/Version-0.2.16-informational?style=flat-square) ![AppVersion: v0.5.3](https://img.shields.io/badge/AppVersion-v0.5.3-informational?style=flat-square)
+![Version: 0.2.17](https://img.shields.io/badge/Version-0.2.17-informational?style=flat-square) ![AppVersion: v0.5.3](https://img.shields.io/badge/AppVersion-v0.5.3-informational?style=flat-square)
 
 Prometheus / OpenMetrics exporter for GitLab CI pipelines insights
 
@@ -47,7 +47,7 @@ Prometheus / OpenMetrics exporter for GitLab CI pipelines insights
 | ingress.path | string | `"/webhook"` | path on the exporter to point the root of the ingress |
 | ingress.pathType | string | `"Prefix"` | pathType for the ingress |
 | ingress.service.port.name | string | `"http"` | service port for the ingress |
-| ingress.tls | list | `[{"hosts":["gcpe.example.com"]}]` | ingress tls hosts config |
+| ingress.tls | list | `[{"hosts":["gcpe.example.com"],"secretName":{}}]` | ingress tls hosts config |
 | labels | object | `{}` | additional labels for the service |
 | livenessProbe.httpGet.path | string | `"/health/live"` |  |
 | livenessProbe.httpGet.port | int | `8080` |  |

--- a/charts/gitlab-ci-pipelines-exporter/templates/ingress.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/templates/ingress.yaml
@@ -20,8 +20,8 @@ spec:
       {{- range .hosts }}
         - {{ . }}
       {{- end }}
-      {{- if .secretName }}
-      secretName: {{ .secretName }}
+      {{- with .secretName }}
+      secretName: {{ toYaml . }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/gitlab-ci-pipelines-exporter/values.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/values.yaml
@@ -220,6 +220,7 @@ ingress:
   tls:
     - hosts:
         - gcpe.example.com
+      secretName: {}
 
 # rbac -- If your kubernetes cluster defined the pod security policy, then you need to enable this part, and define clusterRole based on your situation.
 rbac:


### PR DESCRIPTION
Fixes https://github.com/mvisonneau/helm-charts/issues/51

The property was being used in the ingress.yaml, but there was no default in the values.yaml, resulting in an inconsistency for users who mostly look into values files.
This keeps the same behavior, default `ingress.tls[0].secretName` is empty.

README has been updated, and fix version has been bumped. 

Let me know if there's anything I could add.

Signed-off-by: cebidhem <cebidhem@pm.me>