### PR TITLE
Add missing whitespace in the templating tag

### DIFF
--- a/charts/gitlab-ci-pipelines-exporter/templates/deployment.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
                   name: {{ . }}
                   key: gitlabToken
 {{- end }}
-{{- with .Values.webhookSecret}}
+{{- with .Values.webhookSecret }}
             - name: GCPE_WEBHOOK_SECRET_TOKEN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Helm renders the chart fine but flux chokes on it for some reason so it is worth fixing.

Thank you for the helm chart!