### PR TITLE
Don't encode string in base64 when using stringData

### DIFF
--- a/charts/gitlab-ci-pipelines-exporter/templates/secret.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/templates/secret.yaml
@@ -13,7 +13,7 @@ stringData:
 {{- fail "gitlab token must be set" }}
 {{- end }}
 {{- if .Values.config.redis }}
-  GCPE_REDIS_URL: {{ .Values.config.redis.url | b64enc }}
+  GCPE_REDIS_URL: {{ .Values.config.redis.url }}
 {{- else if .Values.redis.enabled }}
   GCPE_REDIS_URL: {{ printf "redis://%s-redis-master.%s.svc:6379" .Release.Name .Release.Namespace }}
 {{- end }}


### PR DESCRIPTION
.Values.config.redis.url is encoded in base64 twice.

This fix the issue