### PR TITLE
fix(gitlab-ci-pipelines-exporter): remove too long labels

### DIFF
--- a/charts/gitlab-ci-pipelines-exporter/Chart.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: gitlab-ci-pipelines-exporter
-version: 0.2.18
+version: 0.2.19
 appVersion: v0.5.4
 description: Prometheus / OpenMetrics exporter for GitLab CI pipelines insights
 home: https://github.com/mvisonneau/gitlab-ci-pipelines-exporter

--- a/charts/gitlab-ci-pipelines-exporter/templates/deployment.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/templates/deployment.yaml
@@ -20,7 +20,6 @@ spec:
     metadata:
       labels:
         {{- include "app.labels" . | nindent 8 }}
-        helm.sh/from: deploy.{{ include "app.fullname" . }}
 {{ with .Values.podLabels }}{{ toYaml . | indent 8 }}{{ end }}
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}

--- a/charts/gitlab-ci-pipelines-exporter/templates/service.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/templates/service.yaml
@@ -22,4 +22,3 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "app.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    helm.sh/from: deploy.{{ include "app.fullname" . }}


### PR DESCRIPTION
As these labels are not really needed, I would suggest just to remove them, because they can cause install/upgrade errors as mentioned in https://github.com/mvisonneau/helm-charts/issues/60.