### PR TITLE
fix(approuvez): remove too long labels

### DIFF
--- a/charts/approuvez/Chart.yaml
+++ b/charts/approuvez/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: approuvez
-version: 0.1.0
+version: 0.1.1
 appVersion: v0.1.0
 description: CLI helper to obtain live confirmation from people over Slack
 home: https://github.com/mvisonneau/approuvez

--- a/charts/approuvez/README.md
+++ b/charts/approuvez/README.md
@@ -1,6 +1,6 @@
 # approuvez
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 CLI helper to obtain live confirmation from people over Slack
 

--- a/charts/approuvez/templates/deployment.yaml
+++ b/charts/approuvez/templates/deployment.yaml
@@ -13,7 +13,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "app.name" . }}
-      helm.sh/from: deploy.{{ include "app.fullname" . }}
 {{- with .Values.strategy }}
   strategy: {{ toYaml . | nindent 4 }}
 {{- end }}

--- a/charts/approuvez/templates/service.yaml
+++ b/charts/approuvez/templates/service.yaml
@@ -22,4 +22,3 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "app.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    helm.sh/from: deploy.{{ include "app.fullname" . }}


### PR DESCRIPTION
Remove a possible too long label in Helm Chart for approuvez, first appeared as issue in gitlab-ci-pipelines-exporter.
see: https://github.com/mvisonneau/helm-charts/issues/60