### PR TITLE
fix(generic-app): remove too long labels

### DIFF
--- a/charts/generic-app/Chart.yaml
+++ b/charts/generic-app/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: Generic Application Chart
 name: generic-app
-version: 0.0.16
+version: 0.0.17
 appVersion: 0.0.0
 home: https://github.com/mvisonneau/helm-charts
 sources:

--- a/charts/generic-app/README.md
+++ b/charts/generic-app/README.md
@@ -1,6 +1,6 @@
 # generic-app
 
-![Version: 0.0.16](https://img.shields.io/badge/Version-0.0.16-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version: 0.0.17](https://img.shields.io/badge/Version-0.0.17-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
 
 Generic Application Chart
 

--- a/charts/generic-app/templates/daemonset.yaml
+++ b/charts/generic-app/templates/daemonset.yaml
@@ -21,11 +21,9 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "app.name" . }}
-      helm.sh/from: deploy.{{ include "app.fullname" . }}
   template:
     metadata:
       {{- include "generic.labels" . | nindent 6 }}
-        helm.sh/from: deploy.{{ include "app.fullname" . }}
         {{- include "pods.podLabels" . | nindent 8 }}
       {{- with .Values.pods.podAnnotations }}
       annotations: {{ toYaml . | nindent 8 }}

--- a/charts/generic-app/templates/deployment.yaml
+++ b/charts/generic-app/templates/deployment.yaml
@@ -22,11 +22,9 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "app.name" . }}
-      helm.sh/from: deploy.{{ include "app.fullname" . }}
   template:
     metadata:
       {{- include "generic.labels" . | nindent 6 }}
-        helm.sh/from: deploy.{{ include "app.fullname" . }}
         {{- include "pods.podLabels" . | nindent 8 }}
       {{- with .Values.pods.podAnnotations }}
       annotations: {{ toYaml . | nindent 8 }}

--- a/charts/generic-app/templates/service.yaml
+++ b/charts/generic-app/templates/service.yaml
@@ -13,5 +13,4 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "app.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    helm.sh/from: deploy.{{ include "app.fullname" . }}
 {{- end }}

--- a/charts/generic-app/templates/statefulset.yaml
+++ b/charts/generic-app/templates/statefulset.yaml
@@ -21,11 +21,9 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "app.name" . }}
-      helm.sh/from: deploy.{{ include "app.fullname" . }}
   template:
     metadata:
       {{- include "generic.labels" . | nindent 6 }}
-        helm.sh/from: deploy.{{ include "app.fullname" . }}
         {{- include "pods.podLabels" . | nindent 8 }}
       {{- with .Values.pods.podAnnotations }}
       annotations: {{ toYaml . | nindent 8 }}


### PR DESCRIPTION
Remove a possible too long label in Helm Chart for generic-app, first appeared as issue in gitlab-ci-pipelines-exporter.
see: https://github.com/mvisonneau/helm-charts/issues/60