### PR TITLE
fix(unpoller): remove too long label

### DIFF
--- a/charts/unpoller/Chart.yaml
+++ b/charts/unpoller/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: unpoller
-version: 0.0.2
+version: 0.0.3
 appVersion: 2.1.3
 description: Deploy UniFi Poller
 home: https://unpoller.com

--- a/charts/unpoller/README.md
+++ b/charts/unpoller/README.md
@@ -1,6 +1,6 @@
 # unpoller
 
-![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![AppVersion: 2.1.3](https://img.shields.io/badge/AppVersion-2.1.3-informational?style=flat-square)
+![Version: 0.0.3](https://img.shields.io/badge/Version-0.0.3-informational?style=flat-square) ![AppVersion: 2.1.3](https://img.shields.io/badge/AppVersion-2.1.3-informational?style=flat-square)
 
 Deploy UniFi Poller
 

--- a/charts/unpoller/templates/deployment.yaml
+++ b/charts/unpoller/templates/deployment.yaml
@@ -17,7 +17,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "app.name" . }}
-      helm.sh/from: deploy.{{ include "app.fullname" . }}
 {{- with .Values.strategy }}
   strategy: {{ toYaml . | nindent 4 }}
 {{- end }}
@@ -29,7 +28,6 @@ spec:
         helm.sh/chart: {{ include "app.chart" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
-        helm.sh/from: deploy.{{ include "app.fullname" . }}
 {{ with .Values.podLabels }}{{ toYaml . | indent 8 }}{{ end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}


### PR DESCRIPTION
Remove a possible too long label in Helm Chart for unpoller, first appeared as issue in gitlab-ci-pipelines-exporter.
see: https://github.com/mvisonneau/helm-charts/issues/60