### PR TITLE
[gitlab-ci-pipeline-exporter] Update serviceAccountName template in the Deployment

### DIFF
--- a/charts/gitlab-ci-pipelines-exporter/templates/deployment.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
 {{ with .Values.podAnnotations }}{{ toYaml . | indent 8 }}{{ end }}
     spec:
       {{- if .Values.rbac.enabled }}
-      serviceAccountName: {{ template "exporter.serviceAccountName" . }}
+      serviceAccountName: {{ template "app.serviceAccountName" . }}
       {{- end }}
       {{- if .Values.imagePullCredentials }}
       imagePullSecrets:


### PR DESCRIPTION
The name of the template was changed from `exporter.serviceAccountName` to `app.serviceAccountName` in acea05b, but not updated in the Deployment. This caused the templating to fail when `rbac.enabled` was set.

```
Error: template: gitlab-ci-pipelines-exporter/templates/deployment.yaml:30:38: executing "gitlab-ci-pipelines-exporter/templates/deployment.yaml" at <{{template "exporter.serviceAccountName" .}}>: template "exporter.serviceAccountName" not defined
```