### PR TITLE
fix: use value instead of missing template

### DIFF
--- a/charts/gitlab-ci-pipelines-exporter/templates/servicemonitor.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/templates/servicemonitor.yaml
@@ -14,5 +14,5 @@ spec:
     matchLabels:
       {{- include "app.selectorLabels" . | nindent 6 }}
   endpoints:
-    {{- include "app.serviceMonitor.endpoints" . | nindent 4 }}
+    {{- .Values.serviceMonitor.endpoints | toYaml | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
@mvisonneau there was a small problem with your latest change: https://github.com/mvisonneau/helm-charts/commit/effddc6dd9c2e7db5a251705e251377102ba4593#r119644504