### PR TITLE
tailscale-relay: bumped to v1.46.1

### DIFF
--- a/charts/tailscale-relay/Chart.yaml
+++ b/charts/tailscale-relay/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: v2
 name: tailscale-relay
-version: 0.2.3
-appVersion: v1.40.1
+version: 0.2.4
+appVersion: v1.46.1
 description: Deploy a tailscale relay on top of kubernetes
 home: https://github.com/mvisonneau/tailscale-relay-over-k8s
 sources:

--- a/charts/tailscale-relay/README.md
+++ b/charts/tailscale-relay/README.md
@@ -1,6 +1,6 @@
 # tailscale-relay
 
-![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![AppVersion: v1.40.1](https://img.shields.io/badge/AppVersion-v1.40.1-informational?style=flat-square)
+![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![AppVersion: v1.46.1](https://img.shields.io/badge/AppVersion-v1.46.1-informational?style=flat-square)
 
 Deploy a tailscale relay on top of kubernetes
 


### PR DESCRIPTION
Bump version to the latest docker image version: https://hub.docker.com/r/mvisonneau/tailscale/tags

Related with: https://github.com/mvisonneau/docker-tailscale/pull/23

Tested on a cluster overriding `image.tag`. Seems to be working as expected

@mvisonneau