### PR TITLE
Allow config of the container portName

### DIFF
--- a/charts/gitlab-ci-pipelines-exporter/templates/deployment.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/templates/deployment.yaml
@@ -76,7 +76,7 @@ spec:
               mountPath: /etc/config.yml
               subPath: config.yml
           ports:
-            - name: exporter
+            - name: {{- .Values.portName }}
               containerPort: 8080
               protocol: TCP
 {{- with .Values.livenessProbe }}

--- a/charts/gitlab-ci-pipelines-exporter/values.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/values.yaml
@@ -44,6 +44,8 @@ podLabels: {}
 # podAnnotations -- additional annotations for the pods
 podAnnotations: {}
 
+portName: "exporter"
+
 service:
   # type -- service type
   type: ClusterIP


### PR DESCRIPTION
Our prometheus scraping setup relies on a label on the pod and the name of the port in order to discover the port to scrape for metrics.

This change allows us to set the name of the port.