### PR TITLE
feat: add support for existing secret containing the unpoller config

### DIFF
--- a/charts/unpoller/Chart.yaml
+++ b/charts/unpoller/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: unpoller
-version: 0.0.4
+version: 0.1.0
 appVersion: v2.9.2
 description: Deploy UniFi Poller
 home: https://unpoller.com
@@ -10,3 +10,6 @@ sources:
 maintainers:
   - name: mvisonneau
     email: maxime.visonneau@gmail.com
+annotations:
+  artifacthub.io/changes: |
+    - Add support for existing secrets that contain the unpoller config

--- a/charts/unpoller/templates/deployment.yaml
+++ b/charts/unpoller/templates/deployment.yaml
@@ -77,4 +77,8 @@ spec:
       volumes:
         - name: config
           secret:
+            {{- if .Values.unpoller.existingSecret }}
+            secretName: {{ .Values.unpoller.existingSecret }}
+            {{- else }}
             secretName: {{ template "app.fullname" . }}-config
+            {{- end }}

--- a/charts/unpoller/templates/secret.yaml
+++ b/charts/unpoller/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{ if not .Values.unpoller.existingSecret }}
 ---
 apiVersion: v1
 kind: Secret
@@ -11,3 +12,4 @@ type: Opaque
 stringData:
   up.conf: |-
     {{- .Values.unpoller.config | nindent 4 }}
+{{ end }}

--- a/charts/unpoller/values.yaml
+++ b/charts/unpoller/values.yaml
@@ -96,8 +96,10 @@ securityContext: {}
 ## Arguments to append to the command
 # args:
 
-## unpoller.config in TOML format
 unpoller:
+  ## Use an existing Kubernetes secret that contains the unpoller config
+  existingSecret: ""
+  ## Literal unpoller.config in TOML format
   config: |
     # Unpoller v2 primary configuration file. TOML FORMAT #
     ###########################################################


### PR DESCRIPTION
Hey there,

I am already using your chart for quite a while.

However, I had to manually adapt the generated secret, because I didn't want to expose any credentials in my values.yaml. Since I am following a GitOps approach, I have a drift from my source code due to that.

This small PR will add a support to load the unpoller config from an existing secret. In my case I am using the external-secrets-operator (https://external-secrets.io) to load it from another source.