### PR TITLE
charts/gitlab-ci-pipelines-exporter: secret naming and redis resources (0.3.6)

### DIFF
--- a/charts/gitlab-ci-pipelines-exporter/Chart.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: gitlab-ci-pipelines-exporter
-version: 0.3.5
+version: 0.3.6
 appVersion: v0.5.10
 description: Prometheus / OpenMetrics exporter for GitLab CI pipelines insights
 home: https://github.com/mvisonneau/gitlab-ci-pipelines-exporter

--- a/charts/gitlab-ci-pipelines-exporter/README.md
+++ b/charts/gitlab-ci-pipelines-exporter/README.md
@@ -1,6 +1,6 @@
 # gitlab-ci-pipelines-exporter
 
-![Version: 0.3.5](https://img.shields.io/badge/Version-0.3.5-informational?style=flat-square) ![AppVersion: v0.5.10](https://img.shields.io/badge/AppVersion-v0.5.10-informational?style=flat-square)
+![Version: 0.3.6](https://img.shields.io/badge/Version-0.3.6-informational?style=flat-square) ![AppVersion: v0.5.10](https://img.shields.io/badge/AppVersion-v0.5.10-informational?style=flat-square)
 
 Prometheus / OpenMetrics exporter for GitLab CI pipelines insights
 

--- a/charts/gitlab-ci-pipelines-exporter/templates/deployment.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/templates/deployment.yaml
@@ -70,7 +70,7 @@ spec:
 {{- end }}
           envFrom:
             - secretRef:
-                name: {{ template "app.fullname" . }}-config
+                name: {{ template "app.fullname" . }}-secret
           volumeMounts:
             - name: config
               mountPath: /etc/config.yml

--- a/charts/gitlab-ci-pipelines-exporter/templates/secret.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/templates/secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "app.fullname" . }}-config
+  name: {{ template "app.fullname" . }}-secret
   labels:
     {{- include "app.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/gitlab-ci-pipelines-exporter/values.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/values.yaml
@@ -129,7 +129,7 @@ config:
   # # Complete configuration syntax reference available here:
   # # https://github.com/mvisonneau/gitlab-ci-pipelines-exporter/blob/master/docs/configuration_syntax.md
   # gitlab:
-  #   url: https://gitlab.example.com
+  #   url: https://gitlab.example.com/
   #   token: <your_token>
   #   enable_health_check: true
   #   enable_tls_verify: true

--- a/charts/gitlab-ci-pipelines-exporter/values.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/values.yaml
@@ -195,6 +195,15 @@ redis:
     persistence:
       # redis.master.persistence.enabled -- persist data
       enabled: false
+  
+    # redis.master.resources -- configure redis resources
+    resources: {}
+    #  requests:
+    #    cpu: 1
+    #    memory: 256Mi
+    #  limits:
+    #    cpu: 2
+    #    memory: 512Mi 
 
 ## Ingress configuration (useful when looking to expose /webhook endpoint externally)
 ingress:


### PR DESCRIPTION
This PR is to change the secret naming for gitlab-ci-pipelines-exporter/templates/secret.yaml from the current `{{ template "app.fullname" . }}-config` to `{{ template "app.fullname" . }}-secret`.  

The current setup brings back Warnings for users using the Helm chart with ArgoCD deployments: `RepeatedResourceWarning - Resource /ConfigMap/monitoring/gitlab-ci-pipelines-exporter-config appeared 2 times among application resources`. This change also follows the naming convention for Kubernetes resources/objects that are consistent across the chart.  

Redis resource configuratino has also been added as for large GitLab instances the default values are often too small for usage.

An additional minute change is for the GitLab URL link in the commet section adding a trailing slash in the end. Some users have encountered Readiness probe HTTP 503 errors when setting up and a more specific example might be helpful.

Make tests for docs, lint and kubeconform completed. Chart version bumped to 0.3.6 as well.
