### PR TITLE
chore(gitlab-ci-pipelines-exporter): add metricRelabelings support to serviceMonitor

### DIFF
--- a/charts/gitlab-ci-pipelines-exporter/README.md
+++ b/charts/gitlab-ci-pipelines-exporter/README.md
@@ -78,6 +78,7 @@ Prometheus / OpenMetrics exporter for GitLab CI pipelines insights
 | serviceMonitor.enabled | bool | `false` | deploy a serviceMonitor resource |
 | serviceMonitor.endpoints | list | `[{"interval":"10s","port":"http"}]` | endpoints configuration for the monitor |
 | serviceMonitor.labels | object | `{}` | additional labels for the service monitor |
+| serviceMonitor.metricRelabelings | list | `[]` | additional metricRelabelings for the service monitor |
 | strategy | object | `{"type":"RollingUpdate"}` | deployment strategy type |
 | tolerations | list | `[]` | tolerations for pod assignment # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ |
 | webhookSecret | string | `""` | name of a `Secret` containing the webhook token in the `webhookToken` field (required unless `config.server.webhook.secret_token` is specified) |

--- a/charts/gitlab-ci-pipelines-exporter/templates/servicemonitor.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/templates/servicemonitor.yaml
@@ -15,4 +15,6 @@ spec:
       {{- include "app.selectorLabels" . | nindent 6 }}
   endpoints:
     {{- .Values.serviceMonitor.endpoints | toYaml | nindent 4 }}
+  metricRelabelings:
+    {{- .Values.serviceMonitor.metricRelabelings | toYaml | nindent 4 }}
 {{- end }}

--- a/charts/gitlab-ci-pipelines-exporter/values.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/values.yaml
@@ -170,8 +170,16 @@ serviceMonitor:
   # serviceMonitor.annotations -- additional annotations for the service monitor
   annotations: {}
 
-  # serviceMonitor.metricRelabelings -- additional metricRelabelings for the service monitor
+  ## serviceMonitor.metricRelabelings to apply to samples after scraping, but before ingestion.
+  ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#relabelconfig
+  ##
   metricRelabelings: []
+  # eg:
+  # - sourceLabels: [__name__, variables]
+  #   regex: gitlab_ci_pipeline_.*;.*,*MY_PIPELINE_VAR:([^,]+),*.*
+  #   targetLabel: my_pipeline_var
+  #   replacement: $1
+  #   action: replace
 
 ## Spin up a redis pod using the bitnami chart
 ## https://github.com/bitnami/charts/blob/master/bitnami/redis

--- a/charts/gitlab-ci-pipelines-exporter/values.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/values.yaml
@@ -170,6 +170,9 @@ serviceMonitor:
   # serviceMonitor.annotations -- additional annotations for the service monitor
   annotations: {}
 
+  # serviceMonitor.metricRelabelings -- additional metricRelabelings for the service monitor
+  metricRelabelings: []
+
 ## Spin up a redis pod using the bitnami chart
 ## https://github.com/bitnami/charts/blob/master/bitnami/redis
 redis:


### PR DESCRIPTION

Relablings wasn't added here [effddc6](https://github.com/mvisonneau/helm-charts/commit/effddc6dd9c2e7db5a251705e251377102ba4593), so should properly close this one https://github.com/mvisonneau/helm-charts/issues/27 