### PR TITLE
[gitlab-ci-pipelines-exporter] Update version of redis dependency

### DIFF
--- a/charts/gitlab-ci-pipelines-exporter/Chart.lock
+++ b/charts/gitlab-ci-pipelines-exporter/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 20.4.0
-digest: sha256:f8f8b613402327ab70fc8de0d4ee9b0d853e0b7b42a795a2643ebd9f6f8ad34d
-generated: "2025-01-14T18:12:41.506671+01:00"
+  version: 22.0.7
+digest: sha256:c6915192702b26232babff3e2b27c08ef90b4c6fa2eb91856f68efa70ad53b41
+generated: "2025-09-18T19:08:12.254685925Z"

--- a/charts/gitlab-ci-pipelines-exporter/Chart.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: gitlab-ci-pipelines-exporter
-version: 0.3.5
+version: 0.3.6
 appVersion: v0.5.10
 description: Prometheus / OpenMetrics exporter for GitLab CI pipelines insights
 home: https://github.com/mvisonneau/gitlab-ci-pipelines-exporter
@@ -12,6 +12,6 @@ maintainers:
     email: maxime.visonneau@gmail.com
 dependencies:
   - name: redis
-    version: 20.4.0
+    version: 22.0.7
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled


### PR DESCRIPTION
After the Bitnami's registry cleanup, many of the Redis images are no longer there, and new pulls for Redis will result in image-not-found. This patch bumps the dependency to the version that uses the new Bitnami's registry layout