### PR TITLE
bitname charts retirement - transitional update to repository bitnamilegacy

### DIFF
--- a/charts/gitlab-ci-pipelines-exporter/Chart.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: gitlab-ci-pipelines-exporter
-version: 0.3.5
+version: 0.3.6
 appVersion: v0.5.10
 description: Prometheus / OpenMetrics exporter for GitLab CI pipelines insights
 home: https://github.com/mvisonneau/gitlab-ci-pipelines-exporter
@@ -12,6 +12,6 @@ maintainers:
     email: maxime.visonneau@gmail.com
 dependencies:
   - name: redis
-    version: 20.4.0
+    version: 23.0.2
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled

--- a/charts/gitlab-ci-pipelines-exporter/README.md
+++ b/charts/gitlab-ci-pipelines-exporter/README.md
@@ -1,6 +1,6 @@
 # gitlab-ci-pipelines-exporter
 
-![Version: 0.3.5](https://img.shields.io/badge/Version-0.3.5-informational?style=flat-square) ![AppVersion: v0.5.10](https://img.shields.io/badge/AppVersion-v0.5.10-informational?style=flat-square)
+![Version: 0.3.6](https://img.shields.io/badge/Version-0.3.6-informational?style=flat-square) ![AppVersion: v0.5.10](https://img.shields.io/badge/AppVersion-v0.5.10-informational?style=flat-square)
 
 Prometheus / OpenMetrics exporter for GitLab CI pipelines insights
 

--- a/charts/gitlab-ci-pipelines-exporter/values.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/values.yaml
@@ -173,6 +173,12 @@ serviceMonitor:
 ## Spin up a redis pod using the bitnami chart
 ## https://github.com/bitnami/charts/blob/master/bitnami/redis
 redis:
+
+  global:
+    security:
+      ## @param global.security.allowInsecureImages Allows skipping image verification
+      allowInsecureImages: true
+      
   # redis.enabled -- deploy a redis statefulset
   enabled: true
 
@@ -195,6 +201,22 @@ redis:
     persistence:
       # redis.master.persistence.enabled -- persist data
       enabled: false
+  image:
+    # image.repository -- image repository
+    # registry: docker.io
+
+    repository: bitnamilegacy/redis
+    
+    # image.tag -- image tag
+    # tag: <default to chart version>
+
+    # image.pullPolicy -- image pullPolicy
+    # pullPolicy: IfNotPresent
+
+    # image.pullSecrets -- Optional array of imagePullSecrets containing private registry credentials
+    # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    pullSecrets: []
+    # - name: secretName
 
 ## Ingress configuration (useful when looking to expose /webhook endpoint externally)
 ingress:


### PR DESCRIPTION
With the retirement of docker.io/bitnami we can't use the chart with its default redis enabled status, it would require publishing a new version that pulls an image from bitnamilegacy and makes it clear how it's set up in values to the unavoidable date that we need to use our own registry.
