### PR TITLE
gitlab-ci-pipelines-exporter: add support for redis configuration options

### DIFF
--- a/charts/gitlab-ci-pipelines-exporter/Chart.yaml
+++ b/charts/gitlab-ci-pipelines-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: gitlab-ci-pipelines-exporter
-version: 0.3.5
+version: 0.3.6
 appVersion: v0.5.10
 description: Prometheus / OpenMetrics exporter for GitLab CI pipelines insights
 home: https://github.com/mvisonneau/gitlab-ci-pipelines-exporter

--- a/charts/gitlab-ci-pipelines-exporter/README.md
+++ b/charts/gitlab-ci-pipelines-exporter/README.md
@@ -1,6 +1,6 @@
 # gitlab-ci-pipelines-exporter
 
-![Version: 0.3.5](https://img.shields.io/badge/Version-0.3.5-informational?style=flat-square) ![AppVersion: v0.5.10](https://img.shields.io/badge/AppVersion-v0.5.10-informational?style=flat-square)
+![Version: 0.3.6](https://img.shields.io/badge/Version-0.3.6-informational?style=flat-square) ![AppVersion: v0.5.10](https://img.shields.io/badge/AppVersion-v0.5.10-informational?style=flat-square)
 
 Prometheus / OpenMetrics exporter for GitLab CI pipelines insights
 

--- a/charts/gitlab-ci-pipelines-exporter/templates/_helpers.tpl
+++ b/charts/gitlab-ci-pipelines-exporter/templates/_helpers.tpl
@@ -112,6 +112,22 @@ gitlab:
   {{- end }}
 
 {{- end }}
+{{- with .Values.config.redis }}
+{{/*
+Sanitized version of the redis config. "url" is passed as environment variable
+*/}}
+redis:
+  {{- with .project_ttl }}
+  project_ttl: {{ . }}
+  {{- end }}
+  {{- with .ref_ttl }}
+  ref_ttl: {{ . }}
+  {{- end }}
+  {{- with .metric_ttl }}
+  metric_ttl: {{ . }}
+  {{- end }}
+
+{{- end }}
 {{- with .Values.config.pull }}
 pull: {{ toYaml . | nindent 2 }}
 


### PR DESCRIPTION
This PR adds redis TTL configuration options to the sanitized configmap. 
Otherwise, redis entries always expire after 1h (metrics, refs) and 168h (projects). When using webhooks this leads to frequent metric loss for pipelines that don't run every hour. Missing metrics lead to a broken/empty Grafana Dashboard.

See TTL configuration options in the gitlab-ci-pipelines-exporter:
https://github.com/mvisonneau/gitlab-ci-pipelines-exporter/blob/721b566a8176b61e35d43e57f522df350698df8a/pkg/config/config.go#L136-L138